### PR TITLE
Add torso highlight using Vision body pose detection

### DIFF
--- a/lumetonea/Screens/Camera/CameraView.swift
+++ b/lumetonea/Screens/Camera/CameraView.swift
@@ -27,9 +27,10 @@ struct CameraView: View {
                     }
                 }()
 
-                RoundedRectangle(cornerRadius: 12)
-                    .strokeBorder(color, lineWidth: 5)
+                RoundedRectangle(cornerRadius: 40)
+                    .strokeBorder(color, lineWidth: 3)
                     .padding(24)
+                    .padding(.top, 40)
 
                 if let torso = camera.torsoPoints, torso.count == 4 {
                     Path { path in
@@ -57,7 +58,7 @@ struct CameraView: View {
                         .padding(.horizontal, 16)
                         .padding(.vertical, 12)
                         .background(.ultraThinMaterial, in: Capsule())
-                        .padding(.bottom, 150)
+                        .padding(.bottom, 130)
                 }
 
                 if debugEnabled, let d = camera.debugInfo {
@@ -113,7 +114,8 @@ struct CameraView: View {
                         }
                     }
                 }
-                .padding([.top, .leading, .trailing], 16)
+                .padding(.horizontal, 24)
+                .padding(.top, 56)
 
                 Spacer()
 

--- a/lumetonea/Screens/Camera/CameraView.swift
+++ b/lumetonea/Screens/Camera/CameraView.swift
@@ -31,6 +31,23 @@ struct CameraView: View {
                     .strokeBorder(color, lineWidth: 5)
                     .padding(24)
 
+                if let torso = camera.torsoPoints, torso.count == 4 {
+                    Path { path in
+                        let convert: (CGPoint) -> CGPoint = { pt in
+                            CGPoint(
+                                x: pt.x * geo.size.width,
+                                y: (1 - pt.y) * geo.size.height
+                            )
+                        }
+                        path.move(to: convert(torso[0]))
+                        path.addLine(to: convert(torso[1]))
+                        path.addLine(to: convert(torso[2]))
+                        path.addLine(to: convert(torso[3]))
+                        path.closeSubpath()
+                    }
+                    .fill(Color.blue.opacity(0.3))
+                }
+
                 // Optional guidance text
                 VStack {
                     HStack { Spacer() }

--- a/lumetonea/Screens/Camera/CameraViewModel.swift
+++ b/lumetonea/Screens/Camera/CameraViewModel.swift
@@ -10,6 +10,7 @@ final class CameraViewModel: NSObject, ObservableObject {
     @Published var complianceStatus: ComplianceStatus = .detecting
     @Published var statusMessage: String = "Fit head and shoulders in frame"
     @Published var debugInfo: FaceDebugInfo?
+    @Published var torsoPoints: [CGPoint]?
 
     // Calibration targets (nil = use defaults)
     @Published var targetFaceHeight: CGFloat? = nil
@@ -113,7 +114,7 @@ extension CameraViewModel: AVCaptureVideoDataOutputSampleBufferDelegate {
 
         guard let pixelBuffer = CMSampleBufferGetImageBuffer(sampleBuffer) else { return }
 
-        let request = VNDetectFaceLandmarksRequest { [weak self] req, _ in
+        let faceRequest = VNDetectFaceLandmarksRequest { [weak self] req, _ in
             guard let self else { return }
 
             if let faces = req.results as? [VNFaceObservation], let face = faces.first {
@@ -145,8 +146,31 @@ extension CameraViewModel: AVCaptureVideoDataOutputSampleBufferDelegate {
             }
         }
 
+        let bodyRequest = VNDetectHumanBodyPoseRequest { [weak self] req, _ in
+            guard let self else { return }
+            guard let obs = req.results as? [VNHumanBodyPoseObservation],
+                  let result = obs.first,
+                  let points = try? result.recognizedPoints(.all) else {
+                DispatchQueue.main.async { self.torsoPoints = nil }
+                return
+            }
+            guard let ls = points[.leftShoulder],
+                  let rs = points[.rightShoulder],
+                  let lh = points[.leftHip],
+                  let rh = points[.rightHip],
+                  ls.confidence > 0.1,
+                  rs.confidence > 0.1,
+                  lh.confidence > 0.1,
+                  rh.confidence > 0.1 else {
+                DispatchQueue.main.async { self.torsoPoints = nil }
+                return
+            }
+            let torso = [ls, rs, rh, lh].map { CGPoint(x: CGFloat($0.x), y: CGFloat($0.y)) }
+            DispatchQueue.main.async { self.torsoPoints = torso }
+        }
+
         let orientation: CGImagePropertyOrientation = .leftMirrored
-        do { try sequenceRequestHandler.perform([request], on: pixelBuffer, orientation: orientation) } catch {}
+        do { try sequenceRequestHandler.perform([faceRequest, bodyRequest], on: pixelBuffer, orientation: orientation) } catch {}
     }
 }
 


### PR DESCRIPTION
## Summary
- overlay detected torso region in camera preview
- use VNDetectHumanBodyPoseRequest to identify shoulders and hips

## Testing
- `swift build` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*

------
https://chatgpt.com/codex/tasks/task_e_68c2adf637848326871ce57c55b92943